### PR TITLE
Fix/78.Update settings.py so the SECRET_KEY will be hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # jpydzr6-monkeys
 
+# Set SECRET_KEY
+
+The secret key is not included in the repository, the user must provide it itself following these steps:
+- In the directory `monkeys/monkeys/` create an `.env` file
+- In this file save the key: `SECRET_KEY='your_secret_key'`. Remember the single quotation mark for the key itself.  
+
 # Monetary class
 
 This is a class for basic monetary/money operations. In its core it operates in the smallest unit of a currency (called

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jpydzr6-monkeys
 
-# Set SECRET_KEY
+# Set the SECRET_KEY
 
 The secret key is not included in the repository, the user must provide it itself following these steps:
 - In the directory `monkeys/monkeys/` create an `.env` file

--- a/monkeys/monkeys/settings.py
+++ b/monkeys/monkeys/settings.py
@@ -10,17 +10,23 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
+import os
 from pathlib import Path
+import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Get environment variables
+env = environ.Env()
+environ.Env.read_env()
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-!9to5sd1*c6qcads@b3+a5k$)74ua@mf_b_)3=629@o3=$7brg'
+SECRET_KEY = env('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Django==5.1.4
 pytest
 pytest-django
 django-bootstrap-v5
+django-environ==0.12.0


### PR DESCRIPTION
- Usunięto klucz aplikacji z ustawień
- Dodano instrukcję jak dodać własny klucz
- Zaktualizowano `settings.py`, by pobierał klucz z pliku .env

[JPYDZR6MON-78](https://jira.is-academy.pl/browse/JPYDZR6MON-78)